### PR TITLE
fix docstring for `trigger_sync`, remove default value for `connection_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Docstring for `trigger_sync` task and removed inappropriate default value for `connection_id` - [#26](https://github.com/PrefectHQ/prefect-airbyte/pull/26)
 
 ## 0.1.2
 

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -11,23 +11,20 @@ async def export_configuration(
     airbyte_server_port: int = "8000",
     airbyte_api_version: str = "v1",
     timeout: int = 5,
-) -> bytearray:
+) -> bytes:
 
     """
-    Task that exports an Airbyte config via `{AIRBYTE_HOST}/api/v1/deployment/export`
+    Prefect Task that exports an Airbyte configuration via
+    `{airbyte_server_host}/api/v1/deployment/export`.
+
     Args:
-        airbyte_server_host (str, optional): Hostname of Airbyte server where
-            connection is configured. Will overwrite the value provided at init
-            if provided.
-        airbyte_server_port (str, optional): Port that the Airbyte server is
-            listening on, will overwrite the value provided at init if provided.
-        airbyte_api_version (str, optional): Version of Airbyte API to use to
-            trigger connection sync, will overwrite the value provided at
-            init if provided.
-        timeout (int): timeout in seconds on the httpx AirbyteClient
+        airbyte_server_host: Airbyte instance hostname where connection is configured.
+        airbyte_server_port: Port where Airbyte instance is listening.
+        airbyte_api_version: Version of Airbyte API to use to export configuration.
+        timeout: Timeout in seconds on the `httpx.AsyncClient`.
 
     Returns:
-        bytearray: `bytearray` containing Airbyte configuration
+        Bytes containing Airbyte configuration
 
     Examples:
 
@@ -41,7 +38,7 @@ async def export_configuration(
 
         @task
         def zip_and_write_somewhere(
-            airbyte_configuration: bytearray
+            airbyte_configuration: bytes
             somewhere: str = 'my_destination.gz','
         ):
             with gzip.open('my_destination.gz', 'wb') as f:

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -44,28 +44,22 @@ async def trigger_sync(
     when it receives an error status code from an API call.
 
     Args:
-        connection_id (str): the Airbyte connection ID to trigger a sync for.
-        airbyte_server_host (str, optional): Hostname of Airbyte server where the
-            connection is configured. Defaults to "localhost".
-        airbyte_server_port (int, optional): Port where Airbyte instance is listening.
-            Defaults to "8000".
-        airbyte_api_version (str, optional): Version of Airbyte API to use to trigger
-            connection sync. Defaults to "v1".
-        poll_interval_s (int, optional): how often to poll the
-            Airbyte API for sync status. Defaults to 15 seconds.
-        status_updates (bool, optional): whether to log sync job status while polling.
-            Defaults to False.
-        timeout (int, optional): The POST request `timeout` for the `httpx.AsyncClient`.
-            Defaults to 5.
+        connection_id: Airbyte connection ID to trigger a sync for.
+        airbyte_server_host: Airbyte instance hostname where connection is configured.
+        airbyte_server_port: Port where Airbyte instance is listening.
+        airbyte_api_version: Version of Airbyte API to use to trigger connection sync.
+        poll_interval_s: How often to poll Airbyte for sync status.
+        status_updates: Whether to log sync job status while polling.
+        timeout: The POST request `timeout` for the `httpx.AsyncClient`.
 
     Raises:
-        ValueError: if `connection_id` is not a valid UUID
-        err.AirbyteSyncJobFailed: if airbyte returns `JOB_STATUS_FAILED`
-        err.AirbyteConnectionInactiveException: if a specified connection is inactive
-        err.AirbyeConnectionDeprecatedException: if a specified connection is deprecated
+        ValueError: If `connection_id` is not a valid UUID.
+        err.AirbyteSyncJobFailed: If airbyte returns `JOB_STATUS_FAILED`.
+        err.AirbyteConnectionInactiveException: If a given connection is inactive.
+        err.AirbyeConnectionDeprecatedException: If a given connection is deprecated.
 
     Returns:
-        dict: job metadata, including the connection ID and final status
+        Job metadata, including the connection ID and final status of the sync.
 
     Examples:
 

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -69,23 +69,23 @@ async def trigger_sync(
 
     Examples:
 
-            Flow that triggers an Airybte connection sync:
+        Flow that triggers an Airybte connection sync:
 
-            ```python
-            from prefect import flow
-            from prefect_airbyte.connections import trigger_sync
+        ```python
+        from prefect import flow
+        from prefect_airbyte.connections import trigger_sync
 
 
-            @flow
-            def example_trigger_sync_flow():
+        @flow
+        def example_trigger_sync_flow():
 
-                # Run other tasks and subflows here
+            # Run other tasks and subflows here
 
-                trigger_sync(
-                    connection_id="your-connection-id-to-sync"
-                )
+            trigger_sync(
+                connection_id="your-connection-id-to-sync"
+            )
 
-            example_trigger_sync_flow()
+        example_trigger_sync_flow()
     """
     logger = get_logger()
 

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -86,6 +86,7 @@ async def trigger_sync(
             )
 
         example_trigger_sync_flow()
+        ```
     """
     logger = get_logger()
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-airbyte! 🎉-->

## Summary
- the `trigger_sync` task's `connection_id` argument had a default value `None`, should instead require a specified value
- Docstring for `trigger_sync` was formatted incorrectly, causing bad doc renders


## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-airbyte/blob/main/CHANGELOG.md)
