### PR TITLE
add `stream_logs` parameter to `trigger_sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- `stream_logs` parameter to `trigger_sync` to surface airbyte job logs through prefect logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
+- `stream_logs` parameter to `trigger_sync` to surface airbyte job logs through Prefect run logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
 ### Changed
-- return value of `AirbyteClient.get_job_status` to `job_metadata: dict` to simplify inclusion of logs and future job metadata fields - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
-- logger used by all tasks from standard python logger to Prefect logger via `get_run_logger()`. As a consequence, also changed are the unit tests format, namely we're calling all tasks via a `test_flow` instead of calling tasks underlying function with `.fn()` to allow for use of the prefect logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
+- Return value of `AirbyteClient.get_job_status` to `job_metadata: dict` to simplify inclusion of logs and future job metadata fields - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
+- Logger used by all tasks from standard python logger to Prefect logger via `get_run_logger()`. As a consequence, also changed are the unit tests format, namely we're calling all tasks via a `test_flow` instead of calling tasks underlying function with `.fn()` to allow for use of the prefect logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+- `stream_logs` parameter to `trigger_sync` to surface airbyte job logs through prefect logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
 ### Changed
+- return value of `AirbyteClient.get_job_status` to `job_metadata: dict` to simplify inclusion of logs and future job metadata fields - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
+- logger used by all tasks from standard python logger to Prefect logger via `get_run_logger()`. As a consequence, also changed are the unit tests format, namely we're calling all tasks via a `test_flow` instead of calling tasks underlying function with `.fn()` to allow for use of the prefect logger - [#28](https://github.com/PrefectHQ/prefect-airbyte/pull/28)
 
 ### Deprecated
 

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -200,6 +200,7 @@ class AirbyteClient:
             }
 
             if stream_logs and attempts:
+                # always grab logs for most recent attempt of this job
                 job_info["logs"] = attempts[0]["logs"]["logLines"]
                 job_info["n_log_lines"] = len(job_info["logs"])
             else:

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -199,7 +199,7 @@ class AirbyteClient:
                 field: raw_job[field] for field in ["status", "createdAt", "updatedAt"]
             }
 
-            if stream_logs and len(attempts) != 0:
+            if stream_logs and attempts:
                 job_info["logs"] = attempts[0]["logs"]["logLines"]
                 job_info["n_log_lines"] = len(job_info["logs"])
             else:

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -1,6 +1,5 @@
 """Tasks for updating and fetching Airbyte configurations"""
-from prefect import task
-from prefect.logging.loggers import get_logger
+from prefect import get_run_logger, task
 
 from prefect_airbyte.client import AirbyteClient
 
@@ -61,7 +60,7 @@ async def export_configuration(
         ```
     """
 
-    logger = get_logger()
+    logger = get_run_logger()
 
     airbyte_base_url = (
         f"http://{airbyte_server_host}:"

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -123,6 +123,7 @@ async def trigger_sync(
             job_status = job_metadata["status"]
 
             if stream_logs and job_metadata["logs"]:
+                # only log lines created since last job status check
                 new_log_lines = job_metadata["logs"][n_log_lines:]
                 logger.info("\n".join(new_log_lines))
                 n_log_lines = job_metadata["n_log_lines"]

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -49,7 +49,7 @@ async def trigger_sync(
         airbyte_server_port: Port where Airbyte instance is listening.
         airbyte_api_version: Version of Airbyte API to use to trigger connection sync.
         poll_interval_s: How often to poll Airbyte for sync status.
-        stream_logs: whether to include airbyte job logs in Prefect task logs
+        stream_logs: Whether to include airbyte job logs in Prefect task logs.
         status_updates: Whether to log sync job status while polling.
         timeout: The POST request `timeout` for the `httpx.AsyncClient`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ def airbyte_base_job_status_response() -> dict:
 @pytest.fixture
 def airbyte_get_good_job_status_response(airbyte_base_job_status_response) -> dict:
     airbyte_base_job_status_response["job"]["status"] = "succeeded"
+    airbyte_base_job_status_response["attempts"] = [
+        {"logs": {"logLines": "loggy log logs".split()}}
+    ]
     return airbyte_base_job_status_response
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,15 +1,23 @@
 import pytest
+from prefect import flow
 
 from prefect_airbyte import exceptions as err
 from prefect_airbyte.configuration import export_configuration
 
 
 async def test_export_configuration(mock_successful_config_export_calls):
-    export = await export_configuration.fn()
+    @flow
+    async def test_flow():
+        return await export_configuration()
 
+    export = await test_flow()
     assert type(export) is bytes
 
 
 async def test_export_configuration_failed_health(mock_failed_health_check_calls):
+    @flow
+    async def test_flow():
+        await export_configuration()
+
     with pytest.raises(err.AirbyteServerNotHealthyException):
-        await export_configuration.fn()
+        await test_flow()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,4 +1,5 @@
 import pytest
+from prefect import flow
 
 from prefect_airbyte import exceptions as err
 from prefect_airbyte.connections import trigger_sync
@@ -6,10 +7,14 @@ from prefect_airbyte.connections import trigger_sync
 CONNECTION_ID = "e1b2078f-882a-4f50-9942-cfe34b2d825b"
 
 
-async def test_successful_trigger_sync(mock_successful_connection_sync_calls):
-    trigger_sync_result = await trigger_sync.fn(connection_id=CONNECTION_ID)
+@flow
+async def basic_trigger_sync_flow(stream_logs=False):
+    return await trigger_sync(connection_id=CONNECTION_ID, stream_logs=stream_logs)
 
-    assert type(trigger_sync_result) is dict
+
+async def test_successful_trigger_sync(mock_successful_connection_sync_calls):
+
+    trigger_sync_result = await basic_trigger_sync_flow()
 
     assert trigger_sync_result == {
         "connection_id": "e1b2078f-882a-4f50-9942-cfe34b2d825b",
@@ -17,34 +22,62 @@ async def test_successful_trigger_sync(mock_successful_connection_sync_calls):
         "job_status": "succeeded",
         "job_created_at": 1650644844,
         "job_updated_at": 1650644844,
+        "logs": None,
+    }
+
+
+async def test_successful_trigger_sync_with_logs(mock_successful_connection_sync_calls):
+
+    trigger_sync_result = await basic_trigger_sync_flow(stream_logs=True)
+
+    assert trigger_sync_result == {
+        "connection_id": "e1b2078f-882a-4f50-9942-cfe34b2d825b",
+        "status": "active",
+        "job_status": "succeeded",
+        "job_created_at": 1650644844,
+        "job_updated_at": 1650644844,
+        "logs": "loggy log logs".split(),
     }
 
 
 async def test_cancelled_trigger_manual_sync(mock_cancelled_connection_sync_calls):
     with pytest.raises(err.AirbyteSyncJobFailed):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
 
 
 async def test_connection_sync_inactive(mock_inactive_sync_calls):
     with pytest.raises(err.AirbyteConnectionInactiveException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
 
 
 async def test_failed_trigger_sync(mock_failed_connection_sync_calls):
     with pytest.raises(err.AirbyteSyncJobFailed):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
 
 
 async def test_bad_connection_id(mock_bad_connection_id_calls):
     with pytest.raises(err.ConnectionNotFoundException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
 
 
 async def test_failed_health_check(mock_failed_health_check_calls):
     with pytest.raises(err.AirbyteServerNotHealthyException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
 
 
 async def test_get_job_status_not_found(mock_invalid_job_status_calls):
     with pytest.raises(err.JobNotFoundException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await basic_trigger_sync_flow()
+
+
+async def test_get_job_status_no_logs(mock_successful_connection_sync_calls):
+    job_metadata = await basic_trigger_sync_flow()
+
+    assert not job_metadata["logs"]
+
+
+async def test_get_job_status_stream_logs(mock_successful_connection_sync_calls):
+    job_metadata = await basic_trigger_sync_flow(stream_logs=True)
+
+    assert isinstance(job_metadata["logs"], list)
+    assert isinstance(job_metadata["logs"][0], str)


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-airbyte! 🎉-->

## Summary
This PR includes exposes a `stream_logs` parameter to the `trigger_sync` task to surface airbyte sync logs through the Prefect logger and adds associated tests / fixtures.

This required refactoring `AirbyteClient.get_job_status` to conditionally return logs if `stream_output` is True.

This PR also switches from the standard python logger to the logger fetched by `get_run_logger()`, which required a change to all associated unit tests that previously called the `Task.fn()` method.

## Relevant Issue(s)
addresses #19 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-airbyte/blob/main/CHANGELOG.md)
