### PR TITLE
Add `AirbyteServer` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## 0.2.0
+## 0.1.3
 
 Released on November 16, 2022.
 
-This release introduces breaking changes by changing the default interface for tasks in this collection. Previously, tasks accepted individual kwargs like `airbyte_server_host` and `airbyte_server_port` that were needed to construct the base url and make API calls. Now that Airbyte supports basic user/password authentication, it made sense to create an `AirbyteServer` block that stores this user auth data and uses it to configure clients. 
+This release does not introduce breaking changes, but changes the default interface for tasks in this collection. Previously, tasks only accepted individual kwargs like `airbyte_server_host` and `airbyte_server_port` that were needed to construct the base url and make API calls. Now that Airbyte supports basic user/password authentication, it made sense to create an `AirbyteServer` block that stores this user auth data and uses it to configure clients. 
 
-We will create an `AirbyteServer` on the fly for users who continue to pass the old kwargs, but print a message that they will eventually be deprecated.
+We will create an `AirbyteServer` on the fly for users who continue to pass the old kwargs, but print a message that they will eventually be removed from the interface.
 
 ### Added
-- Airbyte server block to handle client generation and support for NGINX authentication on OSS instances - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
+- `AirbyteServer` block to handle client generation and support for NGINX authentication on OSS instances - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
 - Deprecation warning on `AirbyteClient.export_configuration`, as OSS airbyte v0.40.7 has removed the corresponding endpoint - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
+- The `httpx.AsyncClient` as a private member of the class, so we could use the whole `AirbyteClient` as a context manager when it is retrieved by `AirbyteServer.get_client` - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
 
 ### Changed
 - Task inputs for `trigger_sync` and `export_configuration` from accepting Airbyte network configurations as separate kwargs to accepting an `AirbyteServer` block instance - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Released on November 16, 2022.
 
-This release introduces breaking changes by changing the default interface for tasks in this collection.
+This release introduces breaking changes by changing the default interface for tasks in this collection. Previously, tasks accepted individual kwargs like `airbyte_server_host` and `airbyte_server_port` that were needed to construct the base url and make API calls. Now that Airbyte supports basic user/password authentication, it made sense to create an `AirbyteServer` block that stores this user auth data and uses it to configure clients. 
+
+We will create an `AirbyteServer` on the fly for users who continue to pass the old kwargs, but print a message that they will eventually be deprecated.
 
 ### Added
 - Airbyte server block to handle client generation and support for NGINX authentication on OSS instances - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
 ### Deprecated
 
 ### Removed
+
+## 0.2.0
+
+Released on November 16, 2022.
+
+This release introduces breaking changes by changing the default interface for tasks in this collection.
+
+### Added
+- Airbyte server block to handle client generation and support for NGINX authentication on OSS instances - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
+- Deprecation warning on `AirbyteClient.export_configuration`, as OSS airbyte v0.40.7 has removed the corresponding endpoint - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
+
+### Changed
+- Task inputs for `trigger_sync` and `export_configuration` from accepting Airbyte network configurations as separate kwargs to accepting an `AirbyteServer` block instance - [#40](https://github.com/PrefectHQ/prefect-airbyte/pull/40)
+
 
 ### Fixed
 - Docstring for `trigger_sync` task and removed inappropriate default value for `connection_id` - [#26](https://github.com/PrefectHQ/prefect-airbyte/pull/26)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ local_airbyte_server = AirbyteServer()
 remote_airbyte_server = AirbyteServer(
     username="Marvin",
     password="DontPanic42",
-    server_host="<someIP>",
+    server_host="42.42.42.42",
     server_port="4242"
 )
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,33 @@ pip install prefect-airbyte
 ```
 
 ### Examples
+#### Create an `AirbyteServer` block and save it
+```python
+from prefect_airbyte.server import AirbyteServer
+
+# running airbyte locally at http://localhost:8000 with default auth
+local_airbyte_server = AirbyteServer()
+
+# running airbyte remotely at http://<someIP>:<somePort> as user `Marvin`
+remote_airbyte_server = AirbyteServer(
+    username="Marvin",
+    password="DontPanic42",
+    server_host="<someIP>",
+    server_port="4242"
+)
+
+local_airbyte_server.save("my-local-airbyte-server")
+
+remote_airbyte_server.save("my-remote-airbyte-server")
+
+```
+
 
 #### Trigger a defined connection sync
 ```python
 from prefect import flow
 from prefect_airbyte.connections import trigger_sync
-
+from prefect_airbyte.server import AirbyteServer
 
 @flow
 def example_trigger_sync_flow():
@@ -55,6 +76,7 @@ def example_trigger_sync_flow():
       # Run other tasks and subflows here
 
       trigger_sync(
+            airbyte_server=AirbyteServer.load("my-airbyte-server"),
             connection_id="your-connection-id-to-sync",
             poll_interval_s=3,
             status_updates=True
@@ -83,11 +105,15 @@ example_trigger_sync_flow()
 
 
 #### Export an Airbyte instance's configuration
+
+**NOTE**: The API endpoint corresponding to this task is no longer supported by open-source Airbyte versions as of v0.40.7. Check out the [Octavia CLI docs](https://github.com/airbytehq/airbyte/tree/master/octavia-cli) for more info.
+
 ```python
 import gzip
 
 from prefect import flow, task
 from prefect_airbyte.configuration import export_configuration
+from prefect_airbyte.server import AirbyteServer
 
 @task
 def zip_and_write_somewhere(
@@ -103,9 +129,7 @@ def example_export_configuration_flow(filepath: str):
     # Run other tasks and subflows here
 
     airbyte_config = export_configuration(
-        airbyte_server_host="localhost",
-        airbyte_server_port="8000",
-        airbyte_api_version="v1",
+        airbyte_server=AirbyteServer.load("my-airbyte-server-block")
     )
 
     zip_and_write_somewhere(

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,1 @@
+::: prefect_airbyte.server

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,3 +50,4 @@ nav:
     - Client: client.md
     - Configuration: configuration.md
     - Connections: connections.md
+    - Server: server.md

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -39,7 +39,7 @@ class AirbyteClient:
         self.auth = auth
         self.logger = logger
         self.timeout = timeout
-        self.client = httpx.AsyncClient(
+        self._client = httpx.AsyncClient(
             base_url=self.airbyte_base_url, auth=self.auth, timeout=self.timeout
         )
 
@@ -88,7 +88,7 @@ class AirbyteClient:
         get_connection_url = self.airbyte_base_url + "/deployment/export/"
 
         try:
-            response = await self.client.post(get_connection_url)
+            response = await self._client.post(get_connection_url)
             response.raise_for_status()
 
             self.logger.debug("Export configuration response: %s", response)
@@ -116,7 +116,7 @@ class AirbyteClient:
         get_connection_url = self.airbyte_base_url + "/connections/get/"
 
         try:
-            response = await self.client.post(
+            response = await self._client.post(
                 get_connection_url, json={"connectionId": connection_id}
             )
 
@@ -147,7 +147,7 @@ class AirbyteClient:
         get_connection_url = self.airbyte_base_url + "/connections/sync/"
 
         try:
-            response = await self.client.post(
+            response = await self._client.post(
                 get_connection_url, json={"connectionId": connection_id}
             )
             response.raise_for_status()
@@ -178,7 +178,7 @@ class AirbyteClient:
         """
         get_connection_url = self.airbyte_base_url + "/jobs/get/"
         try:
-            response = await self.client.post(get_connection_url, json={"id": job_id})
+            response = await self._client.post(get_connection_url, json={"id": job_id})
             response.raise_for_status()
 
             job = response.json()["job"]
@@ -202,7 +202,7 @@ class AirbyteClient:
 
         self._started = True
 
-        await self.check_health_status(self.client)
+        await self.check_health_status(self._client)
 
         return self
 
@@ -210,4 +210,4 @@ class AirbyteClient:
         """Context manager exit point."""
 
         self._closed = True
-        await self.client.__aexit__()
+        await self._client.__aexit__()

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -22,7 +22,6 @@ class AirbyteClient:
         logger: A logger instance used by the client to log messages related to
             API calls.
         timeout: The number of seconds to wait before an API call times out.
-        client: An `httpx.AsyncClient` instance used to make API calls.
     """
 
     def __init__(
@@ -194,11 +193,11 @@ class AirbyteClient:
     async def create_client(self) -> httpx.AsyncClient:
         """Convencience method to create a new httpx.AsyncClient.
 
-        To be deprecated in favor of using the entire `AirbyteClient` class
+        To be removed in favor of using the entire `AirbyteClient` class
         as a context manager.
         """
         warn(
-            "Use of this method will be deprecated in a future release - "
+            "Use of this method will be removed in a future release - "
             "please use the `AirbyteClient` class as a context manager.",
             DeprecationWarning,
             stacklevel=2,

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -28,9 +28,11 @@ class AirbyteClient:
         self,
         logger: logging.Logger,
         airbyte_base_url: str = "http://localhost:8000/api/v1",
+        auth: Tuple[str, str] = ("airbyte", "password"),
         timeout: int = 5,
     ):
         self.airbyte_base_url = airbyte_base_url
+        self.auth = auth
         self.logger = logger
         self.timeout = timeout
 
@@ -41,7 +43,7 @@ class AirbyteClient:
         Returns:
             Session used to communicate with the Airbyte API.
         """
-        client = httpx.AsyncClient(timeout=self.timeout)
+        client = httpx.AsyncClient(auth=self.auth, timeout=self.timeout)
         await self.check_health_status(client)
         return client
 

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -83,6 +83,10 @@ class AirbyteClient:
             Gzipped Airbyte configuration data.
         """
         async with self.create_client() as client:
+            self.logger.warning(
+                "As of Airbyte v0.40.7-alpha, the Airbyte API no longer supports "
+                "exporting configurations. See the Octavia CLI docs for more info."
+            )
 
             get_connection_url = self.airbyte_base_url + "/deployment/export/"
 
@@ -95,9 +99,9 @@ class AirbyteClient:
                 export_config = response.content
                 return export_config
             except httpx.HTTPStatusError as e:
-                self.logger.warning(
-                    "As of Airbyte v0.40.7-alpha, the Airbyte API no longer supports "
-                    "exporting configurations. See the Octavia CLI docs for more info."
+                self.logger.error(
+                    "If you are using Airbyte v0.40.7-alpha, there is no longer "
+                    "an API endpoint for exporting configurations."
                 )
                 raise err.AirbyteExportConfigurationFailed() from e
 

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -12,8 +12,7 @@ class AirbyteClient:
     """
     Client class used to call API endpoints on an Airbyte server.
 
-    This client assumes that you're using an OSS Airbyte server which does not require
-    an API key to access its a API.
+    This client currently supports username/password authentication as set in `auth`
 
     For more info, see the [Airbyte docs](https://docs.airbyte.io/api-documentation).
 
@@ -96,6 +95,10 @@ class AirbyteClient:
                 export_config = response.content
                 return export_config
             except httpx.HTTPStatusError as e:
+                self.logger.warning(
+                    "As of Airbyte v0.40.7-alpha, the Airbyte API no longer supports "
+                    "exporting configurations. See the Octavia CLI docs for more info."
+                )
                 raise err.AirbyteExportConfigurationFailed() from e
 
     async def get_connection_status(self, connection_id: str) -> str:
@@ -112,7 +115,6 @@ class AirbyteClient:
 
             get_connection_url = self.airbyte_base_url + "/connections/get/"
 
-            # TODO - Missing auth because Airbyte API currently doesn't yet support auth
             try:
                 response = await client.post(
                     get_connection_url, json={"connectionId": connection_id}
@@ -146,7 +148,6 @@ class AirbyteClient:
 
             get_connection_url = self.airbyte_base_url + "/connections/sync/"
 
-            # TODO - no current authentication methods from Airbyte
             try:
                 response = await client.post(
                     get_connection_url, json={"connectionId": connection_id}

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -191,6 +191,20 @@ class AirbyteClient:
                 raise err.JobNotFoundException(f"Job {job_id} not found.") from e
             raise err.AirbyteServerNotHealthyException() from e
 
+    async def create_client(self) -> httpx.AsyncClient:
+        """Convencience method to create a new httpx.AsyncClient.
+
+        To be deprecated in favor of using the entire `AirbyteClient` class
+        as a context manager.
+        """
+        warn(
+            "Use of this method will be deprecated in a future release - "
+            "please use the `AirbyteClient` class as a context manager.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._client
+
     async def __aenter__(self):
         """Context manager entry point."""
         if self._closed:

--- a/prefect_airbyte/client.py
+++ b/prefect_airbyte/client.py
@@ -12,7 +12,7 @@ class AirbyteClient:
     """
     Client class used to call API endpoints on an Airbyte server.
 
-    This client currently supports username/password authentication as set in `auth`
+    This client currently supports username/password authentication as set in `auth`.
 
     For more info, see the [Airbyte docs](https://docs.airbyte.io/api-documentation).
 

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -1,7 +1,6 @@
 """Tasks for updating and fetching Airbyte configurations"""
 from prefect import get_run_logger, task
 
-from prefect_airbyte.exceptions import AirbyteExportConfigurationFailed
 from prefect_airbyte.server import AirbyteServer
 
 
@@ -60,12 +59,5 @@ async def export_configuration(
     airbyte_client = airbyte_server.get_client(logger=logger, timeout=timeout)
 
     logger.info("Initiating export of Airbyte configuration")
-    try:
-        return await airbyte_client.export_configuration()
 
-    except AirbyteExportConfigurationFailed as e:
-        logger.warning(
-            "As of Airbyte v0.40.7-alpha, the Airbyte API no longer supports "
-            "exporting configurations. See the Octavia CLI docs for more info."
-        )
-        raise e
+    return await airbyte_client.export_configuration()

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -57,11 +57,11 @@ async def export_configuration(
     """
     logger = get_run_logger()
 
-    airbyte = airbyte_server.get_client(logger=logger, timeout=timeout)
+    airbyte_client = airbyte_server.get_client(logger=logger, timeout=timeout)
 
     logger.info("Initiating export of Airbyte configuration")
     try:
-        return await airbyte.export_configuration()
+        return await airbyte_client.export_configuration()
 
     except AirbyteExportConfigurationFailed as e:
         logger.warning(

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -11,6 +11,7 @@ async def export_configuration(
     airbyte_server: Optional[AirbyteServer] = None,
     airbyte_server_host: Optional[str] = None,
     airbyte_server_port: Optional[int] = None,
+    airbyte_api_version: Optional[str] = None,
     timeout: int = 5,
 ) -> bytes:
 
@@ -27,6 +28,7 @@ async def export_configuration(
         airbyte_server: An `AirbyteServer` block for generating an `AirbyteClient`.
         airbyte_server_host: Airbyte server host to connect to.
         airbyte_server_port: Airbyte server port to connect to.
+        airbyte_api_version: Airbyte API version to use.
         timeout: Timeout in seconds on the `httpx.AsyncClient`.
 
     Returns:
@@ -69,18 +71,19 @@ async def export_configuration(
 
     if not airbyte_server:
         logger.warning(
-            "Using kwargs `airbyte_server_host` and `airbyte_server_port` will be  "
-            "deprecated. Please pass an `airbyte_server` block to this task instead."
+            "Using kwargs `airbyte_server_host`, `airbyte_server_port`, `airbyte_api_version` "  # noqa
+            "will be deprecated. Please pass an `airbyte_server` block to this task instead."  # noqa
         )
-        if airbyte_server_host or airbyte_server_port:
+        if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             airbyte_server = AirbyteServer(
                 server_host=airbyte_server_host or "localhost",
                 server_port=airbyte_server_port or 8000,
+                api_version=airbyte_api_version or "v1",
             )
         else:
             airbyte_server = AirbyteServer()
     else:
-        if airbyte_server_host or airbyte_server_port:
+        if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             logger.warning(
                 "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
                 "because `airbyte_server` block was passed."

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -1,15 +1,13 @@
 """Tasks for updating and fetching Airbyte configurations"""
-from prefect import task
-from prefect.logging.loggers import get_logger
+from prefect import get_run_logger, task
 
-from prefect_airbyte.client import AirbyteClient
+from prefect_airbyte.exceptions import AirbyteExportConfigurationFailed
+from prefect_airbyte.server import AirbyteServer
 
 
 @task
 async def export_configuration(
-    airbyte_server_host: str = "localhost",
-    airbyte_server_port: int = "8000",
-    airbyte_api_version: str = "v1",
+    airbyte_server: AirbyteServer,
     timeout: int = 5,
 ) -> bytes:
 
@@ -18,9 +16,7 @@ async def export_configuration(
     `{airbyte_server_host}/api/v1/deployment/export`.
 
     Args:
-        airbyte_server_host: Airbyte instance hostname where connection is configured.
-        airbyte_server_port: Port where Airbyte instance is listening.
-        airbyte_api_version: Version of Airbyte API to use to export configuration.
+        airbyte_server: An `AirbyteServer` block for generating an `AirbyteClient`.
         timeout: Timeout in seconds on the `httpx.AsyncClient`.
 
     Returns:
@@ -35,6 +31,7 @@ async def export_configuration(
 
         from prefect import flow, task
         from prefect_airbyte.configuration import export_configuration
+        from prefect_airbyte.server import AirbyteServer
 
         @task
         def zip_and_write_somewhere(
@@ -50,9 +47,7 @@ async def export_configuration(
             # Run other tasks and subflows here
 
             airbyte_config = export_configuration(
-                    airbyte_server_host="localhost",
-                    airbyte_server_port="8000",
-                    airbyte_api_version="v1",
+                airbyte_server=AirbyteServer.load("oss-airbyte")
             )
 
             zip_and_write_somewhere(airbyte_config=airbyte_config)
@@ -60,17 +55,17 @@ async def export_configuration(
         example_trigger_sync_flow()
         ```
     """
+    logger = get_run_logger()
 
-    logger = get_logger()
-
-    airbyte_base_url = (
-        f"http://{airbyte_server_host}:"
-        f"{airbyte_server_port}/api/{airbyte_api_version}"
-    )
-
-    airbyte = AirbyteClient(logger, airbyte_base_url, timeout=timeout)
+    airbyte = airbyte_server.get_client(logger=logger, timeout=timeout)
 
     logger.info("Initiating export of Airbyte configuration")
-    airbyte_config = await airbyte.export_configuration()
+    try:
+        return await airbyte.export_configuration()
 
-    return airbyte_config
+    except AirbyteExportConfigurationFailed as e:
+        logger.warning(
+            "As of Airbyte v0.40.7-alpha, the Airbyte API no longer supports "
+            "exporting configurations. See the Octavia CLI docs for more info."
+        )
+        raise e

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -90,9 +90,10 @@ async def export_configuration(
     else:
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             logger.info(
-                "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
-                "because `airbyte_server` block was passed. Using API URL from "
-                f"`airbyte_server` block: {airbyte_server.base_url!r}."
+                "Ignoring `airbyte_server_host`, `airbyte_api_version`, "
+                "and `airbyte_server_port` because `airbyte_server` block "
+                " was passed. Using API URL from `airbyte_server` block: "
+                f"{airbyte_server.base_url!r}."
             )
 
     async with airbyte_server.get_client(

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -1,5 +1,6 @@
 """Tasks for updating and fetching Airbyte configurations"""
 from typing import Optional
+from warnings import warn
 
 from prefect import get_run_logger, task
 
@@ -70,9 +71,12 @@ async def export_configuration(
     logger = get_run_logger()
 
     if not airbyte_server:
-        logger.warning(
-            "Using kwargs `airbyte_server_host`, `airbyte_server_port`, `airbyte_api_version` "  # noqa
-            "will be deprecated. Please pass an `airbyte_server` block to this task instead."  # noqa
+        warn(
+            "The use of `airbyte_server_host`, `airbyte_server_port`, and `airbyte_api_version` "  # noqa
+            "is deprecated and will be removed in a future release. Please pass an `airbyte_server` "  # noqa
+            "block to this task instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             airbyte_server = AirbyteServer(
@@ -84,9 +88,10 @@ async def export_configuration(
             airbyte_server = AirbyteServer()
     else:
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
-            logger.warning(
+            logger.info(
                 "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
-                "because `airbyte_server` block was passed."
+                "because `airbyte_server` block was passed. Using API URL from "
+                f"`airbyte_server` block: {airbyte_server.base_url!r}."
             )
 
     async with airbyte_server.get_client(

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -20,7 +20,7 @@ async def export_configuration(
     Prefect Task that exports an Airbyte configuration via
     `{airbyte_server_host}/api/v1/deployment/export`.
 
-    As of `prefect-airbyte==0.2.0`, the kwargs `airbyte_server_host` and
+    As of `prefect-airbyte==0.1.3`, the kwargs `airbyte_server_host` and
     `airbyte_server_port` can be replaced by passing an `airbyte_server` block
     instance to generate the `AirbyteClient`. Using the `airbyte_server` block is
     preferred, but the individual kwargs remain for backwards compatibility.

--- a/prefect_airbyte/configuration.py
+++ b/prefect_airbyte/configuration.py
@@ -72,9 +72,10 @@ async def export_configuration(
 
     if not airbyte_server:
         warn(
-            "The use of `airbyte_server_host`, `airbyte_server_port`, and `airbyte_api_version` "  # noqa
-            "is deprecated and will be removed in a future release. Please pass an `airbyte_server` "  # noqa
-            "block to this task instead.",
+            "The use of `airbyte_server_host`, `airbyte_server_port`, and "
+            "`airbyte_api_version` is deprecated and will be removed in a "
+            "future release. Please pass an `airbyte_server` block to this "
+            "task instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -25,6 +25,7 @@ async def trigger_sync(
     airbyte_server: Optional[AirbyteServer] = None,
     airbyte_server_host: Optional[str] = None,
     airbyte_server_port: Optional[int] = None,
+    airbyte_api_version: Optional[str] = None,
     poll_interval_s: int = 15,
     status_updates: bool = False,
     timeout: int = 5,
@@ -53,6 +54,7 @@ async def trigger_sync(
         airbyte_server: An `AirbyteServer` block to create an `AirbyteClient`.
         airbyte_server_host: Airbyte server host to connect to.
         airbyte_server_port: Airbyte server port to connect to.
+        airbyte_api_version: Airbyte API version to use.
         poll_interval_s: How often to poll Airbyte for sync status.
         status_updates: Whether to log sync job status while polling.
         timeout: The POST request `timeout` for the `httpx.AsyncClient`.
@@ -91,19 +93,20 @@ async def trigger_sync(
     logger = get_run_logger()
 
     if not airbyte_server:
-        if airbyte_server_host or airbyte_server_port:
-            logger.warning(
-                "Using kwargs `airbyte_server_host` and `airbyte_server_port` will be  "
-                "deprecated - pass an `airbyte_server` block to this task instead."
-            )
+        logger.warning(
+            "Using kwargs `airbyte_server_host`, `airbyte_server_port`, `airbyte_api_version` "  # noqa: E501
+            "will be deprecated. Please pass an `airbyte_server` block to this task instead."  # noqa: E501
+        )
+        if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             airbyte_server = AirbyteServer(
                 server_host=airbyte_server_host or "localhost",
                 server_port=airbyte_server_port or 8000,
+                api_version=airbyte_api_version or "v1",
             )
         else:
             airbyte_server = AirbyteServer()
     else:
-        if airbyte_server_host or airbyte_server_port:
+        if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             logger.warning(
                 "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
                 "because `airbyte_server` block was passed."

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -2,6 +2,7 @@
 import uuid
 from asyncio import sleep
 from typing import Optional
+from warnings import warn
 
 from prefect import get_run_logger, task
 
@@ -93,9 +94,12 @@ async def trigger_sync(
     logger = get_run_logger()
 
     if not airbyte_server:
-        logger.warning(
-            "Using kwargs `airbyte_server_host`, `airbyte_server_port`, `airbyte_api_version` "  # noqa: E501
-            "will be deprecated. Please pass an `airbyte_server` block to this task instead."  # noqa: E501
+        warn(
+            "The use of `airbyte_server_host`, `airbyte_server_port`, and `airbyte_api_version` "  # noqa
+            "is deprecated and will be removed in a future release. Please pass an `airbyte_server` "  # noqa
+            "block to this task instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             airbyte_server = AirbyteServer(
@@ -107,9 +111,10 @@ async def trigger_sync(
             airbyte_server = AirbyteServer()
     else:
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
-            logger.warning(
+            logger.info(
                 "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
-                "because `airbyte_server` block was passed."
+                "because `airbyte_server` block was passed. Using API URL from "
+                f"`airbyte_server` block: {airbyte_server.base_url!r}."
             )
 
     try:

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -92,7 +92,7 @@ async def trigger_sync(
 
     logger.info(
         f"Getting Airbyte Connection {connection_id}, poll interval "
-        f"{poll_interval_s} seconds, airbyte_base_url {airbyte_server.airbyte_base_url}"
+        f"{poll_interval_s} seconds, airbyte_base_url {airbyte_server.base_url}"
     )
 
     connection_status = await airbyte_client.get_connection_status(connection_id)

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -113,9 +113,10 @@ async def trigger_sync(
     else:
         if any([airbyte_server_host, airbyte_server_port, airbyte_api_version]):
             logger.info(
-                "Ignoring kwargs `airbyte_server_host` and `airbyte_server_port` "
-                "because `airbyte_server` block was passed. Using API URL from "
-                f"`airbyte_server` block: {airbyte_server.base_url!r}."
+                "Ignoring `airbyte_server_host`, `airbyte_api_version`, "
+                "and `airbyte_server_port` because `airbyte_server` block "
+                " was passed. Using API URL from `airbyte_server` block: "
+                f"{airbyte_server.base_url!r}."
             )
 
     try:

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -45,7 +45,7 @@ async def trigger_sync(
     will only complete when the sync has completed or
     when it receives an error status code from an API call.
 
-    As of `prefect-airbyte==0.2.0`, the kwargs `airbyte_server_host` and
+    As of `prefect-airbyte==0.1.3`, the kwargs `airbyte_server_host` and
     `airbyte_server_port` can be replaced by passing an `airbyte_server` block
     instance to generate the `AirbyteClient`. Using the `airbyte_server` block is
     preferred, but the individual kwargs remain for backwards compatibility.

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -91,11 +91,11 @@ async def trigger_sync(
     logger = get_run_logger()
 
     if not airbyte_server:
-        logger.warning(
-            "Using kwargs `airbyte_server_host` and `airbyte_server_port` will be  "
-            "deprecated. Please pass an `airbyte_server` block to this task instead."
-        )
         if airbyte_server_host or airbyte_server_port:
+            logger.warning(
+                "Using kwargs `airbyte_server_host` and `airbyte_server_port` will be  "
+                "deprecated - pass an `airbyte_server` block to this task instead."
+            )
             airbyte_server = AirbyteServer(
                 server_host=airbyte_server_host or "localhost",
                 server_port=airbyte_server_port or 8000,

--- a/prefect_airbyte/connections.py
+++ b/prefect_airbyte/connections.py
@@ -95,9 +95,10 @@ async def trigger_sync(
 
     if not airbyte_server:
         warn(
-            "The use of `airbyte_server_host`, `airbyte_server_port`, and `airbyte_api_version` "  # noqa
-            "is deprecated and will be removed in a future release. Please pass an `airbyte_server` "  # noqa
-            "block to this task instead.",
+            "The use of `airbyte_server_host`, `airbyte_server_port`, and "
+            "`airbyte_api_version` is deprecated and will be removed in a "
+            "future release. Please pass an `airbyte_server` block to this "
+            "task instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/prefect_airbyte/server.py
+++ b/prefect_airbyte/server.py
@@ -77,7 +77,7 @@ class AirbyteServer(Block):
     )
 
     @property
-    def airbyte_base_url(self) -> str:
+    def base_url(self) -> str:
         """Property containing the base URL for the Airbyte API."""
         protocol = "https" if self.use_ssl else "http"
         return (
@@ -96,7 +96,7 @@ class AirbyteServer(Block):
         """
         return AirbyteClient(
             logger=logger,
-            airbyte_base_url=self.airbyte_base_url,
+            airbyte_base_url=self.base_url,
             auth=(self.username, self.password.get_secret_value()),
             timeout=timeout,
         )

--- a/prefect_airbyte/server.py
+++ b/prefect_airbyte/server.py
@@ -25,7 +25,6 @@ class AirbyteServer(Block):
         from prefect_airbyte.connection import trigger_sync
         from prefect_airbyte.server import AirbyteServer
 
-
         @flow
         def airbyte_orchestration_flow():
             airbyte_server = AirbyteServer()
@@ -43,32 +42,38 @@ class AirbyteServer(Block):
     username: str = Field(
         default="airbyte",
         description="Username to authenticate with Airbyte API.",
+        title="Username",
     )
 
     password: SecretStr = Field(
         default=SecretStr("password"),
         description="Password to authenticate with Airbyte API.",
+        title="Password",
     )
 
     server_host: str = Field(
         default="localhost",
         description="Host address of Airbyte server.",
         example="127.0.0.1",
+        title="Server Host",
     )
 
     server_port: int = Field(
         default=8000,
         description="Port number of Airbyte server.",
+        title="Server Port",
     )
 
     api_version: str = Field(
         default="v1",
         description="Airbyte API version to use.",
+        title="API Version",
     )
 
     use_ssl: bool = Field(
         default=False,
         description="Whether to use SSL when connecting to Airbyte server.",
+        title="Use SSL",
     )
 
     @property

--- a/prefect_airbyte/server.py
+++ b/prefect_airbyte/server.py
@@ -17,6 +17,7 @@ class AirbyteServer(Block):
         server_host: Hostname for Airbyte API.
         server_port: Port for Airbyte API.
         api_version: Version of Airbyte API to use.
+        use_ssl: Whether to use a secure url for calls to the Airbyte API.
 
     Example:
         Create an `AirbyteServer` block for an Airbyte instance running on localhost:
@@ -42,26 +43,22 @@ class AirbyteServer(Block):
     username: str = Field(
         default="airbyte",
         description="Username to authenticate with Airbyte API.",
-        title="Username",
     )
 
     password: SecretStr = Field(
         default=SecretStr("password"),
         description="Password to authenticate with Airbyte API.",
-        title="Password",
     )
 
     server_host: str = Field(
         default="localhost",
         description="Host address of Airbyte server.",
         example="127.0.0.1",
-        title="Server Host",
     )
 
     server_port: int = Field(
         default=8000,
         description="Port number of Airbyte server.",
-        title="Server Port",
     )
 
     api_version: str = Field(

--- a/prefect_airbyte/server.py
+++ b/prefect_airbyte/server.py
@@ -1,10 +1,9 @@
 """A module for defining OSS Airbyte interactions with Prefect."""
 
 from logging import Logger
-from typing import Optional
 
 from prefect.blocks.core import Block
-from pydantic import Field, HttpUrl, IPvAnyAddress, SecretStr
+from pydantic import Field, SecretStr
 
 from prefect_airbyte.client import AirbyteClient
 
@@ -18,7 +17,6 @@ class AirbyteServer(Block):
         server_host: Hostname for Airbyte API.
         server_port: Port for Airbyte API.
         api_version: Version of Airbyte API to use.
-        ```
 
     Example:
         Create an `AirbyteServer` block for an Airbyte instance running on localhost:
@@ -38,11 +36,9 @@ class AirbyteServer(Block):
         ```
     """
 
-    _block_type_name: Optional[str] = "Airbyte Server"
-    _block_type_slug: Optional[str] = "airbyte-server"
-    _logo_url: Optional[
-        HttpUrl
-    ] = "https://images.ctfassets.net/zscdif0zqppk/6gm7wsC7ANnKYQsm7oiSYz/aac1ad5e054d35d9e24af8d6ed3aed5f/59758427?h=250"  # noqa
+    _block_type_name = "Airbyte Server"
+    _block_type_slug = "airbyte-server"
+    _logo_url = "https://images.ctfassets.net/zscdif0zqppk/6gm7wsC7ANnKYQsm7oiSYz/aac1ad5e054d35d9e24af8d6ed3aed5f/59758427?h=250"  # noqa
 
     username: str = Field(
         default="airbyte",
@@ -54,9 +50,10 @@ class AirbyteServer(Block):
         description="Password to authenticate with Airbyte API.",
     )
 
-    server_host: IPvAnyAddress = Field(
-        default="127.0.0.1",
+    server_host: str = Field(
+        default="localhost",
         description="Host address of Airbyte server.",
+        example="127.0.0.1",
     )
 
     server_port: int = Field(
@@ -69,9 +66,18 @@ class AirbyteServer(Block):
         description="Airbyte API version to use.",
     )
 
+    use_ssl: bool = Field(
+        default=False,
+        description="Whether to use SSL when connecting to Airbyte server.",
+    )
+
     @property
     def airbyte_base_url(self) -> str:
-        return f"http://{self.server_host}:{self.server_port}/api/{self.api_version}"
+        """Property containing the base URL for the Airbyte API."""
+        protocol = "https" if self.use_ssl else "http"
+        return (
+            f"{protocol}://{self.server_host}:{self.server_port}/api/{self.api_version}"
+        )
 
     def get_client(self, logger: Logger, timeout: int = 10) -> AirbyteClient:
         """Returns an `AirbyteClient` instance for interacting with the Airbyte API.

--- a/prefect_airbyte/server.py
+++ b/prefect_airbyte/server.py
@@ -1,0 +1,91 @@
+"""A module for defining OSS Airbyte interactions with Prefect."""
+
+from logging import Logger
+from typing import Optional
+
+from prefect.blocks.core import Block
+from pydantic import Field, HttpUrl, IPvAnyAddress, SecretStr
+
+from prefect_airbyte.client import AirbyteClient
+
+
+class AirbyteServer(Block):
+    """A block representing an Airbyte server for generating `AirbyteClient` instances.
+
+    Attributes:
+        username: Username for Airbyte API.
+        password: Password for Airbyte API.
+        server_host: Hostname for Airbyte API.
+        server_port: Port for Airbyte API.
+        api_version: Version of Airbyte API to use.
+        ```
+
+    Example:
+        Create an `AirbyteServer` block for an Airbyte instance running on localhost:
+        ```python
+        from prefect import flow
+        from prefect_airbyte.connection import trigger_sync
+        from prefect_airbyte.server import AirbyteServer
+
+
+        @flow
+        def airbyte_orchestration_flow():
+            airbyte_server = AirbyteServer()
+            trigger_sync(
+                airbyte_server=airbyte_server,
+                connection_id="my_connection_id",
+            )
+        ```
+    """
+
+    _block_type_name: Optional[str] = "Airbyte Server"
+    _block_type_slug: Optional[str] = "airbyte-server"
+    _logo_url: Optional[
+        HttpUrl
+    ] = "https://images.ctfassets.net/zscdif0zqppk/6gm7wsC7ANnKYQsm7oiSYz/aac1ad5e054d35d9e24af8d6ed3aed5f/59758427?h=250"  # noqa
+
+    username: str = Field(
+        default="airbyte",
+        description="Username to authenticate with Airbyte API.",
+    )
+
+    password: SecretStr = Field(
+        default=SecretStr("password"),
+        description="Password to authenticate with Airbyte API.",
+    )
+
+    server_host: IPvAnyAddress = Field(
+        default="127.0.0.1",
+        description="Host address of Airbyte server.",
+    )
+
+    server_port: int = Field(
+        default=8000,
+        description="Port number of Airbyte server.",
+    )
+
+    api_version: str = Field(
+        default="v1",
+        description="Airbyte API version to use.",
+    )
+
+    @property
+    def airbyte_base_url(self) -> str:
+        return f"http://{self.server_host}:{self.server_port}/api/{self.api_version}"
+
+    def get_client(self, logger: Logger, timeout: int = 10) -> AirbyteClient:
+        """Returns an `AirbyteClient` instance for interacting with the Airbyte API.
+
+        Args:
+            logger: Logger instance used to log messages related to API calls.
+            timeout: The number of seconds to wait before an API call times out.
+
+        Returns:
+            An `AirbyteClient` instance.
+        """
+        return AirbyteClient(
+            logger=logger,
+            airbyte_base_url=self.airbyte_base_url,
+            auth=(self.username, self.password.get_secret_value()),
+            timeout=timeout,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,16 @@ import pytest
 import respx
 from httpx import Response
 
+from prefect_airbyte.server import AirbyteServer
+
 # connection fixtures / mocks
 
 CONNECTION_ID = "e1b2078f-882a-4f50-9942-cfe34b2d825b"
+
+
+@pytest.fixture
+def airbyte_server():
+    return AirbyteServer()
 
 
 @pytest.fixture
@@ -148,7 +155,7 @@ def airbyte_job_status_not_found_response():
 
 @pytest.fixture
 def base_airbyte_url():
-    return "http://localhost:8000/api/v1"
+    return "http://127.0.0.1:8000/api/v1"
 
 
 @respx.mock(assert_all_called=True)
@@ -354,4 +361,21 @@ def mock_successful_config_export_calls(
 
     respx_mock.post(url=f"{base_airbyte_url}/deployment/export/").mock(
         return_value=Response(200, content=airbyte_good_export_configuration_response)
+    )
+
+
+@respx.mock(assert_all_called=True)
+@pytest.fixture
+def mock_config_endpoint_not_found(
+    respx_mock,
+    base_airbyte_url,
+    airbyte_good_health_check_response,
+    airbyte_good_export_configuration_response,
+):
+    respx_mock.get(url=f"{base_airbyte_url}/health/").mock(
+        return_value=Response(200, json=airbyte_good_health_check_response)
+    )
+
+    respx_mock.post(url=f"{base_airbyte_url}/deployment/export/").mock(
+        return_value=Response(404)
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def airbyte_job_status_not_found_response():
 
 @pytest.fixture
 def base_airbyte_url():
-    return "http://127.0.0.1:8000/api/v1"
+    return "http://localhost:8000/api/v1"
 
 
 @respx.mock(assert_all_called=True)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,6 +15,18 @@ async def test_export_configuration(
         assert type(export) is bytes
 
 
+async def test_export_configuration_using_kwargs(
+    mock_successful_config_export_calls, airbyte_server
+):
+    with disable_run_logger():
+        export = await export_configuration.fn(
+            airbyte_server_host="localhost",
+            airbyte_server_port=8000,
+        )
+
+        assert type(export) is bytes
+
+
 async def test_export_configuration_failed_health(
     mock_failed_health_check_calls, airbyte_server
 ):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,15 +1,31 @@
 import pytest
+from prefect.logging import disable_run_logger
 
 from prefect_airbyte import exceptions as err
 from prefect_airbyte.configuration import export_configuration
+from prefect_airbyte.exceptions import AirbyteExportConfigurationFailed
 
 
-async def test_export_configuration(mock_successful_config_export_calls):
-    export = await export_configuration.fn()
+async def test_export_configuration(
+    mock_successful_config_export_calls, airbyte_server
+):
+    with disable_run_logger():
+        export = await export_configuration.fn(airbyte_server=airbyte_server)
 
-    assert type(export) is bytes
+        assert type(export) is bytes
 
 
-async def test_export_configuration_failed_health(mock_failed_health_check_calls):
+async def test_export_configuration_failed_health(
+    mock_failed_health_check_calls, airbyte_server
+):
     with pytest.raises(err.AirbyteServerNotHealthyException):
-        await export_configuration.fn()
+        with disable_run_logger():
+            await export_configuration.fn(airbyte_server=airbyte_server)
+
+
+async def test_export_configuration_raise_deprecation_warning(
+    mock_config_endpoint_not_found, airbyte_server
+):
+    with pytest.raises(AirbyteExportConfigurationFailed):
+        with disable_run_logger():
+            await export_configuration.fn(airbyte_server=airbyte_server)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -7,10 +7,10 @@ from prefect_airbyte.connections import trigger_sync
 CONNECTION_ID = "e1b2078f-882a-4f50-9942-cfe34b2d825b"
 
 
-async def example_trigger_sync_flow(airbyte_server):
+async def example_trigger_sync_flow(airbyte_server=None, **kwargs):
     with disable_run_logger():
         return await trigger_sync.fn(
-            airbyte_server=airbyte_server, connection_id=CONNECTION_ID
+            airbyte_server=airbyte_server, connection_id=CONNECTION_ID, **kwargs
         )
 
 
@@ -60,3 +60,20 @@ async def test_failed_health_check(mock_failed_health_check_calls, airbyte_serve
 async def test_get_job_status_not_found(mock_invalid_job_status_calls, airbyte_server):
     with pytest.raises(err.JobNotFoundException):
         await example_trigger_sync_flow(airbyte_server)
+
+
+async def test_trigger_sync_with_kwargs(mock_successful_connection_sync_calls):
+    trigger_sync_result = await example_trigger_sync_flow(
+        airbyte_server_host="localhost",
+        airbyte_server_port=8000,
+    )
+
+    assert type(trigger_sync_result) is dict
+
+    assert trigger_sync_result == {
+        "connection_id": "e1b2078f-882a-4f50-9942-cfe34b2d825b",
+        "status": "active",
+        "job_status": "succeeded",
+        "job_created_at": 1650644844,
+        "job_updated_at": 1650644844,
+    }

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,4 +1,5 @@
 import pytest
+from prefect.logging import disable_run_logger
 
 from prefect_airbyte import exceptions as err
 from prefect_airbyte.connections import trigger_sync
@@ -6,8 +7,17 @@ from prefect_airbyte.connections import trigger_sync
 CONNECTION_ID = "e1b2078f-882a-4f50-9942-cfe34b2d825b"
 
 
-async def test_successful_trigger_sync(mock_successful_connection_sync_calls):
-    trigger_sync_result = await trigger_sync.fn(connection_id=CONNECTION_ID)
+async def example_trigger_sync_flow(airbyte_server):
+    with disable_run_logger():
+        return await trigger_sync.fn(
+            airbyte_server=airbyte_server, connection_id=CONNECTION_ID
+        )
+
+
+async def test_successful_trigger_sync(
+    mock_successful_connection_sync_calls, airbyte_server
+):
+    trigger_sync_result = await example_trigger_sync_flow(airbyte_server)
 
     assert type(trigger_sync_result) is dict
 
@@ -20,31 +30,33 @@ async def test_successful_trigger_sync(mock_successful_connection_sync_calls):
     }
 
 
-async def test_cancelled_trigger_manual_sync(mock_cancelled_connection_sync_calls):
+async def test_cancelled_trigger_manual_sync(
+    mock_cancelled_connection_sync_calls, airbyte_server
+):
     with pytest.raises(err.AirbyteSyncJobFailed):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)
 
 
-async def test_connection_sync_inactive(mock_inactive_sync_calls):
+async def test_connection_sync_inactive(mock_inactive_sync_calls, airbyte_server):
     with pytest.raises(err.AirbyteConnectionInactiveException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)
 
 
-async def test_failed_trigger_sync(mock_failed_connection_sync_calls):
+async def test_failed_trigger_sync(mock_failed_connection_sync_calls, airbyte_server):
     with pytest.raises(err.AirbyteSyncJobFailed):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)
 
 
-async def test_bad_connection_id(mock_bad_connection_id_calls):
+async def test_bad_connection_id(mock_bad_connection_id_calls, airbyte_server):
     with pytest.raises(err.ConnectionNotFoundException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)
 
 
-async def test_failed_health_check(mock_failed_health_check_calls):
+async def test_failed_health_check(mock_failed_health_check_calls, airbyte_server):
     with pytest.raises(err.AirbyteServerNotHealthyException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)
 
 
-async def test_get_job_status_not_found(mock_invalid_job_status_calls):
+async def test_get_job_status_not_found(mock_invalid_job_status_calls, airbyte_server):
     with pytest.raises(err.JobNotFoundException):
-        await trigger_sync.fn(connection_id=CONNECTION_ID)
+        await example_trigger_sync_flow(airbyte_server)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-airbyte 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the `AirbyteServer` block to handle nginx authentication for OSS instance in `AirbyteClient` and store config info about the instance running airbyte.

This PR alters the tasks in this collection to accept an `AirbyteServer` instead of the individual fields, so these are breaking changes.

This PR also adds a deprecation warning to `export_configuration`, as the underlying API endpoint was removed from OSS airbyte as of airbyte v0.40.7

<!-- Link to issue -->
Closes #39 
Closes #21 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->
- [ ] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-airbyte/blob/main/CHANGELOG.md)
